### PR TITLE
19356 drop snowflake stage

### DIFF
--- a/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
@@ -167,22 +167,6 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
   }
 
   @Override
-  protected void doCommit(JdbcOutputConnection con, PluginTask task, int taskCount)
-      throws SQLException {
-    super.doCommit(con, task, taskCount);
-    SnowflakeOutputConnection snowflakeCon = (SnowflakeOutputConnection) con;
-
-    SnowflakePluginTask t = (SnowflakePluginTask) task;
-    if (this.stageIdentifier == null) {
-      this.stageIdentifier = StageIdentifierHolder.getStageIdentifier(t);
-    }
-
-    if (t.getDeleteStage()) {
-      snowflakeCon.runDropStage(this.stageIdentifier);
-    }
-  }
-
-  @Override
   protected void doBegin(
       JdbcOutputConnection con, PluginTask task, final Schema schema, int taskCount)
       throws SQLException {
@@ -196,16 +180,8 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
       throw new UnsupportedOperationException(
           "Snowflake output plugin doesn't support 'merge_direct' mode.");
     }
-
-    SnowflakePluginTask t = (SnowflakePluginTask) task;
-    // TODO: put some where executes once
-    if (this.stageIdentifier == null) {
-      SnowflakeOutputConnection snowflakeCon =
-          (SnowflakeOutputConnection) getConnector(task, true).connect(true);
-      this.stageIdentifier = StageIdentifierHolder.getStageIdentifier(t);
-      snowflakeCon.runCreateStage(this.stageIdentifier);
-    }
     SnowflakePluginTask pluginTask = (SnowflakePluginTask) task;
+    this.stageIdentifier = StageIdentifierHolder.getStageIdentifier(pluginTask);
 
     return new SnowflakeCopyBatchInsert(
         getConnector(task, true),

--- a/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
@@ -147,9 +147,11 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
       snowflakeCon = (SnowflakeOutputConnection) getConnector(task, true).connect(true);
       snowflakeCon.runCreateStage(this.stageIdentifier);
       configDiff = super.transaction(config, schema, taskCount, control);
-      snowflakeCon.runDropStage(this.stageIdentifier);
+      if (t.getDeleteStage()) {
+        snowflakeCon.runDropStage(this.stageIdentifier);
+      }
     } catch (Exception e) {
-      if (t.getDeleteStageOnError()) {
+      if (t.getDeleteStage() && t.getDeleteStageOnError()) {
         try {
           snowflakeCon.runDropStage(this.stageIdentifier);
         } catch (SQLException ex) {

--- a/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
@@ -131,33 +131,31 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
   }
 
   @Override
-  public ConfigDiff transaction(ConfigSource config,
-          Schema schema, int taskCount,
-          OutputPlugin.Control control)
-  {
-      PluginTask task = CONFIG_MAPPER.map(config, this.getTaskClass());
-      SnowflakePluginTask t = (SnowflakePluginTask) task;
-      this.stageIdentifier = StageIdentifierHolder.getStageIdentifier(t);
-      ConfigDiff configDiff;
-      SnowflakeOutputConnection snowflakeCon = null;
+  public ConfigDiff transaction(
+      ConfigSource config, Schema schema, int taskCount, OutputPlugin.Control control) {
+    PluginTask task = CONFIG_MAPPER.map(config, this.getTaskClass());
+    SnowflakePluginTask t = (SnowflakePluginTask) task;
+    this.stageIdentifier = StageIdentifierHolder.getStageIdentifier(t);
+    ConfigDiff configDiff;
+    SnowflakeOutputConnection snowflakeCon = null;
 
-      try {
-        snowflakeCon = (SnowflakeOutputConnection) getConnector(task, true).connect(true);
-        snowflakeCon.runCreateStage(this.stageIdentifier);
-        configDiff = super.transaction(config, schema, taskCount, control);
-      }  catch (SQLException ex) {
-        throw new RuntimeException(ex);
-      }  finally {
-        if (t.getDeleteStage()) {
-          try {
-            snowflakeCon.runDropStage(this.stageIdentifier);
-          }  catch (SQLException ex) {
-            throw new RuntimeException(ex);
-          }
+    try {
+      snowflakeCon = (SnowflakeOutputConnection) getConnector(task, true).connect(true);
+      snowflakeCon.runCreateStage(this.stageIdentifier);
+      configDiff = super.transaction(config, schema, taskCount, control);
+    } catch (SQLException ex) {
+      throw new RuntimeException(ex);
+    } finally {
+      if (t.getDeleteStage()) {
+        try {
+          snowflakeCon.runDropStage(this.stageIdentifier);
+        } catch (SQLException ex) {
+          throw new RuntimeException(ex);
         }
       }
+    }
 
-      return configDiff;
+    return configDiff;
   }
 
   @Override

--- a/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
+++ b/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
@@ -61,7 +61,6 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
   @Override
   public void prepare(TableIdentifier loadTable, JdbcSchema insertSchema) throws SQLException {
     this.connection = (SnowflakeOutputConnection) connector.connect(true);
-    this.connection.runCreateStage(stageIdentifier);
     this.tableIdentifier = loadTable;
   }
 

--- a/src/main/java/org/embulk/output/snowflake/SnowflakeOutputConnection.java
+++ b/src/main/java/org/embulk/output/snowflake/SnowflakeOutputConnection.java
@@ -11,8 +11,12 @@ import org.embulk.output.jdbc.JdbcOutputConnection;
 import org.embulk.output.jdbc.JdbcSchema;
 import org.embulk.output.jdbc.MergeConfig;
 import org.embulk.output.jdbc.TableIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SnowflakeOutputConnection extends JdbcOutputConnection {
+  private final Logger logger = LoggerFactory.getLogger(SnowflakeOutputConnection.class);
+
   public SnowflakeOutputConnection(Connection connection) throws SQLException {
     super(connection, null);
   }
@@ -32,11 +36,13 @@ public class SnowflakeOutputConnection extends JdbcOutputConnection {
   public void runCreateStage(StageIdentifier stageIdentifier) throws SQLException {
     String sql = buildCreateStageSQL(stageIdentifier);
     runUpdate(sql);
+    logger.info("SQL: {}", sql);
   }
 
   public void runDropStage(StageIdentifier stageIdentifier) throws SQLException {
     String sql = buildDropStageSQL(stageIdentifier);
     runUpdate(sql);
+    logger.info("SQL: {}", sql);
   }
 
   public void runUploadFile(


### PR DESCRIPTION
This pull request primarily focuses on improving the error handling and logging in the Snowflake output plugin for Embulk. It introduces a new configuration option, modifies the transaction process, and refactors the stage creation process. It also adds logging to the `runCreateStage` and `runDropStage` methods.

Here are the most significant changes:

New Configuration Option:
* [`src/main/java/org/embulk/output/SnowflakeOutputPlugin.java`](diffhunk://#diff-05c2b1752e71c7d5d413d78a81b5e80ec268850049f70e31f071c3dae13f1cd1R69-R72): Added a new configuration option `delete_stage_on_error` to the `SnowflakePluginTask` interface. This option determines whether to delete the stage if an error occurs during the transaction process.

Transaction Process Modification:
* [`src/main/java/org/embulk/output/SnowflakeOutputPlugin.java`](diffhunk://#diff-05c2b1752e71c7d5d413d78a81b5e80ec268850049f70e31f071c3dae13f1cd1L133-R170): Replaced the `resume` method with a `transaction` method in the `SnowflakeOutputPlugin` class. The new `transaction` method includes error handling to delete the stage if an error occurs and the `delete_stage_on_error` option is set to `true`.

Stage Creation Refactoring:
* [`src/main/java/org/embulk/output/SnowflakeOutputPlugin.java`](diffhunk://#diff-05c2b1752e71c7d5d413d78a81b5e80ec268850049f70e31f071c3dae13f1cd1L168-R188): Removed the stage creation process from the `newBatchInsert` method. The stage is now created in the `transaction` method.
* [`src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java`](diffhunk://#diff-6068c5dc059942ec5aec602ab7d9138764624c3a40f96ec2c27c588796b93829L64): Removed the stage creation process from the `prepare` method.

Logging Addition:
* [`src/main/java/org/embulk/output/snowflake/SnowflakeOutputConnection.java`](diffhunk://#diff-53dc4bf2d1af4f80efab4f18102e8211c7f59693fa44362b10ac2daa04aaea12R39-R45): Added logging to the `runCreateStage` and `runDropStage` methods. The SQL commands executed in these methods are now logged.